### PR TITLE
rename all to v2

### DIFF
--- a/stable/cluster-lifecycle/templates/clustermanagementaddon-clusterrole.yaml
+++ b/stable/cluster-lifecycle/templates/clustermanagementaddon-clusterrole.yaml
@@ -3,7 +3,7 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Values.org }}:{{ .Release.Name }}:clustermanagementaddons-readonly
+  name: {{ .Values.org }}:{{ .Release.Name }}:clustermanagementaddons-readonly-v2
 rules:
 - apiGroups: ["addon.open-cluster-management.io"]
   resources: ["clustermanagementaddons"]

--- a/stable/cluster-lifecycle/templates/clustermanagementaddon-clusterrolebinding.yaml
+++ b/stable/cluster-lifecycle/templates/clustermanagementaddon-clusterrolebinding.yaml
@@ -3,12 +3,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ .Values.org }}:{{ .Release.Name }}:clustermanagementaddons-readonly
+  name: {{ .Values.org }}:{{ .Release.Name }}:clustermanagementaddons-readonly-v2
 subjects:
 - kind: Group
   name: system:authenticated
   apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole
-  name: {{ .Values.org }}:{{ .Release.Name }}:clustermanagementaddons-readonly
+  name: {{ .Values.org }}:{{ .Release.Name }}:clustermanagementaddons-readonly-v2
   apiGroup: rbac.authorization.k8s.io

--- a/stable/cluster-lifecycle/templates/klusterlet-addon-deployment.yaml
+++ b/stable/cluster-lifecycle/templates/klusterlet-addon-deployment.yaml
@@ -4,10 +4,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Values.klusterletAddonController.name }}
+  name: {{ .Values.klusterletAddonController.name }}-v2
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ .Values.klusterletAddonController.name }}
+    app: {{ .Values.klusterletAddonController.name }}-v2
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     component: {{ .Values.klusterletAddonController.name }}
     heritage: {{ .Release.Service }}
@@ -21,13 +21,13 @@ spec:
   replicas: {{ .Values.hubconfig.replicaCount }}
   selector:
     matchLabels:
-      app: {{ .Values.klusterletAddonController.name }}
+      app: {{ .Values.klusterletAddonController.name }}-v2
       component: {{ .Values.klusterletAddonController.name }}
       release: {{ .Release.Name }}
   template:
     metadata:
       labels:
-        app: {{ .Values.klusterletAddonController.name }}
+        app: {{ .Values.klusterletAddonController.name }}-v2
         ocm-antiaffinity-selector: "klusterletaddon"
         component: {{ .Values.klusterletAddonController.name }}
         release: {{ .Release.Name }}
@@ -47,7 +47,7 @@ spec:
       imagePullSecrets:
         - name: {{ .Values.global.imagePullSecret }}
     {{- end }}
-      serviceAccountName: {{ .Values.klusterletAddonController.name }}
+      serviceAccountName: {{ .Values.klusterletAddonController.name }}-v2
       hostNetwork: false
       hostPID: false
       hostIPC: false

--- a/stable/cluster-lifecycle/templates/klusterlet-addon-role.yaml
+++ b/stable/cluster-lifecycle/templates/klusterlet-addon-role.yaml
@@ -5,9 +5,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: {{ .Values.org }}:{{ .Release.Name }}:{{ .Values.klusterletAddonController.name }}
+  name: {{ .Values.org }}:{{ .Release.Name }}:{{ .Values.klusterletAddonController.name }}-v2
   labels:
-    app: {{ .Values.klusterletAddonController.name }}
+    app: {{ .Values.klusterletAddonController.name }}-v2
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     component: {{ .Values.klusterletAddonController.name }}
     heritage: {{ .Release.Service }}

--- a/stable/cluster-lifecycle/templates/klusterlet-addon-role_binding.yaml
+++ b/stable/cluster-lifecycle/templates/klusterlet-addon-role_binding.yaml
@@ -4,9 +4,9 @@
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Values.org }}:{{ .Release.Name }}:{{ .Values.klusterletAddonController.name }}
+  name: {{ .Values.org }}:{{ .Release.Name }}:{{ .Values.klusterletAddonController.name }}-v2
   labels:
-    app: {{ .Values.klusterletAddonController.name }}
+    app: {{ .Values.klusterletAddonController.name }}-v2
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     component: {{ .Values.klusterletAddonController.name }}
     heritage: {{ .Release.Service }}
@@ -17,9 +17,9 @@ metadata:
     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.klusterletAddonController.name }}
+  name: {{ .Values.klusterletAddonController.name }}-v2
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: {{ .Values.org }}:{{ .Release.Name }}:{{ .Values.klusterletAddonController.name }}
+  name: {{ .Values.org }}:{{ .Release.Name }}:{{ .Values.klusterletAddonController.name }}-v2
   apiGroup: rbac.authorization.k8s.io

--- a/stable/cluster-lifecycle/templates/klusterlet-addon-service_account.yaml
+++ b/stable/cluster-lifecycle/templates/klusterlet-addon-service_account.yaml
@@ -4,10 +4,10 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.klusterletAddonController.name }}
+  name: {{ .Values.klusterletAddonController.name }}-v2
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ .Values.klusterletAddonController.name }}
+    app: {{ .Values.klusterletAddonController.name }}-v2
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     component: {{ .Values.klusterletAddonController.name }}
     heritage: {{ .Release.Service }}

--- a/stable/cluster-lifecycle/templates/managedcluster-import-deployment.yaml
+++ b/stable/cluster-lifecycle/templates/managedcluster-import-deployment.yaml
@@ -9,10 +9,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Values.clusterController.name }}
+  name: {{ .Values.clusterController.name }}-v2
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ .Values.clusterController.name }}
+    app: {{ .Values.clusterController.name }}-v2
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     component: {{ .Values.clusterController.name }}
     heritage: {{ .Release.Service }}
@@ -26,13 +26,13 @@ spec:
   replicas: {{ .Values.hubconfig.replicaCount }}
   selector:
     matchLabels:
-      app: {{ .Values.clusterController.name }}
+      app: {{ .Values.clusterController.name }}-v2
       component: {{ .Values.clusterController.name }}
       release: {{ .Release.Name }}
   template:
     metadata:
       labels:
-        app: {{ .Values.clusterController.name }}
+        app: {{ .Values.clusterController.name }}-v2
         ocm-antiaffinity-selector: "managedclusterimport"
         component: {{ .Values.clusterController.name }}
         release: {{ .Release.Name }}
@@ -52,7 +52,7 @@ spec:
       imagePullSecrets:
         - name: {{ .Values.global.imagePullSecret }}
     {{- end }}
-      serviceAccountName: {{ .Values.clusterController.name }}
+      serviceAccountName: {{ .Values.clusterController.name }}-v2
       hostNetwork: false
       hostPID: false
       hostIPC: false

--- a/stable/cluster-lifecycle/templates/managedcluster-import-role.yaml
+++ b/stable/cluster-lifecycle/templates/managedcluster-import-role.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: {{ .Values.org }}:{{ .Release.Name }}:{{ .Values.clusterController.name }}
+  name: {{ .Values.org }}:{{ .Release.Name }}:{{ .Values.clusterController.name }}-v2
   labels:
-    app: {{ .Values.clusterController.name }}
+    app: {{ .Values.clusterController.name }}-v2
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     component: {{ .Values.clusterController.name }}
     heritage: {{ .Release.Service }}

--- a/stable/cluster-lifecycle/templates/managedcluster-import-role_binding.yaml
+++ b/stable/cluster-lifecycle/templates/managedcluster-import-role_binding.yaml
@@ -3,7 +3,7 @@
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Values.org }}:{{ .Release.Name }}:{{ .Values.clusterController.name }}
+  name: {{ .Values.org }}:{{ .Release.Name }}:{{ .Values.clusterController.name }}-v2
   labels:
     app: {{ .Values.clusterController.name }}-v2
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/stable/cluster-lifecycle/templates/managedcluster-import-role_binding.yaml
+++ b/stable/cluster-lifecycle/templates/managedcluster-import-role_binding.yaml
@@ -5,7 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Values.org }}:{{ .Release.Name }}:{{ .Values.clusterController.name }}
   labels:
-    app: {{ .Values.clusterController.name }}
+    app: {{ .Values.clusterController.name }}-v2
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     component: {{ .Values.clusterController.name }}
     heritage: {{ .Release.Service }}
@@ -16,9 +16,9 @@ metadata:
     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.clusterController.name }}
+  name: {{ .Values.clusterController.name }}-v2
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: {{ .Values.org }}:{{ .Release.Name }}:{{ .Values.clusterController.name }}
+  name: {{ .Values.org }}:{{ .Release.Name }}:{{ .Values.clusterController.name }}-v2
   apiGroup: rbac.authorization.k8s.io

--- a/stable/cluster-lifecycle/templates/managedcluster-import-service_account.yaml
+++ b/stable/cluster-lifecycle/templates/managedcluster-import-service_account.yaml
@@ -3,10 +3,10 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.clusterController.name }}
+  name: {{ .Values.clusterController.name }}-v2
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ .Values.clusterController.name }}
+    app: {{ .Values.clusterController.name }}-v2
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     component: {{ .Values.clusterController.name }}
     heritage: {{ .Release.Service }}

--- a/stable/cluster-lifecycle/templates/metrics-clusterrole.yaml
+++ b/stable/cluster-lifecycle/templates/metrics-clusterrole.yaml
@@ -3,9 +3,9 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Values.org }}:{{ .Release.Name }}:{{ .Values.clusterlifecycleStateMetrics.name }}
+  name: {{ .Values.org }}:{{ .Release.Name }}:{{ .Values.clusterlifecycleStateMetrics.name }}-v2
   labels:
-    app: {{ .Values.clusterlifecycleStateMetrics.name }}
+    app: {{ .Values.clusterlifecycleStateMetrics.name }}-v2
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     component: {{ .Values.clusterlifecycleStateMetrics.name }}
     heritage: {{ .Release.Service }}

--- a/stable/cluster-lifecycle/templates/metrics-clusterrole_binding.yaml
+++ b/stable/cluster-lifecycle/templates/metrics-clusterrole_binding.yaml
@@ -3,9 +3,9 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ .Values.org }}:{{ .Release.Name }}:{{ .Values.clusterlifecycleStateMetrics.name }}
+  name: {{ .Values.org }}:{{ .Release.Name }}:{{ .Values.clusterlifecycleStateMetrics.name }}-v2
   labels:
-    app: {{ .Values.clusterlifecycleStateMetrics.name }}
+    app: {{ .Values.clusterlifecycleStateMetrics.name }}-v2
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     component: {{ .Values.clusterlifecycleStateMetrics.name }}
     heritage: {{ .Release.Service }}
@@ -17,8 +17,8 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ .Values.org }}:{{ .Release.Name }}:{{ .Values.clusterlifecycleStateMetrics.name }}
+  name: {{ .Values.org }}:{{ .Release.Name }}:{{ .Values.clusterlifecycleStateMetrics.name }}-v2
 subjects:
   - kind: ServiceAccount
-    name: {{ .Values.clusterlifecycleStateMetrics.name }}
+    name: {{ .Values.clusterlifecycleStateMetrics.name }}-v2
     namespace: {{ .Release.Namespace }}

--- a/stable/cluster-lifecycle/templates/metrics-clusterrolebinding-prom.yaml
+++ b/stable/cluster-lifecycle/templates/metrics-clusterrolebinding-prom.yaml
@@ -3,9 +3,9 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ .Values.org }}:{{ .Release.Name }}:clusterlifecycle-state-metrics-prometheus
+  name: {{ .Values.org }}:{{ .Release.Name }}:{{ .Values.clusterlifecycleStateMetrics.name }}-prometheus-v2
   labels:
-    app: {{ .Values.clusterlifecycleStateMetrics.name }}
+    app: {{ .Values.clusterlifecycleStateMetrics.name }}-v2
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     component: {{ .Values.clusterlifecycleStateMetrics.name }}
     heritage: {{ .Release.Service }}
@@ -17,7 +17,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ .Values.org }}:{{ .Release.Name }}:clusterlifecycle-state-metrics
+  name: {{ .Values.org }}:{{ .Release.Name }}:{{ .Values.clusterlifecycleStateMetrics.name }}-v2
 subjects:
   - kind: ServiceAccount
     name: prometheus-k8s

--- a/stable/cluster-lifecycle/templates/metrics-deployment.yaml
+++ b/stable/cluster-lifecycle/templates/metrics-deployment.yaml
@@ -3,10 +3,10 @@
 kind: Deployment
 apiVersion: apps/v1
 metadata:
-  name: {{ .Values.clusterlifecycleStateMetrics.name }}
+  name: {{ .Values.clusterlifecycleStateMetrics.name }}-v2
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ .Values.clusterlifecycleStateMetrics.name }}
+    app: {{ .Values.clusterlifecycleStateMetrics.name }}-v2
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     component: {{ .Values.clusterlifecycleStateMetrics.name }}
     heritage: {{ .Release.Service }}
@@ -19,11 +19,11 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: {{ .Values.clusterlifecycleStateMetrics.name }}
+      app: {{ .Values.clusterlifecycleStateMetrics.name }}-v2
   template:
     metadata:
       labels:
-        app: {{ .Values.clusterlifecycleStateMetrics.name }}
+        app: {{ .Values.clusterlifecycleStateMetrics.name }}-v2
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
         component: {{ .Values.clusterlifecycleStateMetrics.name }}
         heritage: {{ .Release.Service }}
@@ -37,7 +37,7 @@ spec:
       imagePullSecrets:
         - name: {{ .Values.global.imagePullSecret }}
     {{- end }}
-      serviceAccountName: {{ .Values.clusterlifecycleStateMetrics.name }}
+      serviceAccountName: {{ .Values.clusterlifecycleStateMetrics.name }}-v2
       tolerations:
       - effect: NoSchedule 
         key: node-role.kubernetes.io/infra 

--- a/stable/cluster-lifecycle/templates/metrics-service.yaml
+++ b/stable/cluster-lifecycle/templates/metrics-service.yaml
@@ -3,11 +3,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.clusterlifecycleStateMetrics.name }}
+  name: {{ .Values.clusterlifecycleStateMetrics.name }}-v2
   namespace: {{ .Release.Namespace }}
   labels:
-    clc-app: {{ .Values.clusterlifecycleStateMetrics.name }}
-    app: {{ .Values.clusterlifecycleStateMetrics.name }}
+    clc-app: {{ .Values.clusterlifecycleStateMetrics.name }}-v2
+    app: {{ .Values.clusterlifecycleStateMetrics.name }}-v2
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     component: {{ .Values.clusterlifecycleStateMetrics.name }}
     heritage: {{ .Release.Service }}
@@ -25,4 +25,4 @@ spec:
     port: 8443
     targetPort: 8443
   selector:
-    app: {{ .Values.clusterlifecycleStateMetrics.name }}
+    app: {{ .Values.clusterlifecycleStateMetrics.name }}-v2

--- a/stable/cluster-lifecycle/templates/metrics-service_account.yaml
+++ b/stable/cluster-lifecycle/templates/metrics-service_account.yaml
@@ -3,10 +3,10 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.clusterlifecycleStateMetrics.name }}
+  name: {{ .Values.clusterlifecycleStateMetrics.name }}-v2
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ .Values.clusterlifecycleStateMetrics.name }}
+    app: {{ .Values.clusterlifecycleStateMetrics.name }}-v2
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     component: {{ .Values.clusterlifecycleStateMetrics.name }}
     heritage: {{ .Release.Service }}

--- a/stable/cluster-lifecycle/templates/metrics-servicemonitor.yaml
+++ b/stable/cluster-lifecycle/templates/metrics-servicemonitor.yaml
@@ -3,10 +3,10 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ .Values.clusterlifecycleStateMetrics.name }}
+  name: {{ .Values.clusterlifecycleStateMetrics.name }}-v2
   namespace: openshift-monitoring
   labels:
-    app: {{ .Values.clusterlifecycleStateMetrics.name }}
+    app: {{ .Values.clusterlifecycleStateMetrics.name }}-v2
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     component: {{ .Values.clusterlifecycleStateMetrics.name }}
     heritage: {{ .Release.Service }}
@@ -27,7 +27,7 @@ spec:
   jobLabel: clc-app
   selector:
     matchLabels:
-      clc-app: {{ .Values.clusterlifecycleStateMetrics.name }}
+      clc-app: {{ .Values.clusterlifecycleStateMetrics.name }}-v2
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}


### PR DESCRIPTION
Updates:
- updated all component name to v2
- updated all labels with `app: ...-v2`

Tests:
- [x] can still import/detach properly when installing both old & new charts
- [x] can still import/detach when removing old chart
- [x] can import/detach when installing without old chart (fresh install scenario)