### PR TITLE
Remove .travis.yml and add Github Actions

### DIFF
--- a/.github/workflows/fast-forward.yml
+++ b/.github/workflows/fast-forward.yml
@@ -1,0 +1,19 @@
+name: Push commits to current release branch
+
+on:
+  push:
+    branches:
+    - main
+
+jobs:
+  fast-forward:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Fast-Forward Release
+      uses: JakobGray/branch-fast-forward@v0.1.0
+      with:
+        main_branch: 'main'
+        ff_branch: 'release-2.3'
+        push_token: 'FF_TOKEN'
+      env:
+        FF_TOKEN: ${{ secrets.FF_TOKEN }}

--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -1,0 +1,23 @@
+name: Lint the Helm chart
+
+on:
+  pull_request:
+
+jobs:
+  lint-chart:
+    runs-on: ubuntu-latest
+    env:
+      # where the chart lies within the repo
+      CHART_PATH: stable/cluster-lifecycle
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.2.4
+
+      - name: Lint chart
+        run: |
+          helm version
+          helm lint "$CHART_PATH"

--- a/.github/workflows/push-chart.yml
+++ b/.github/workflows/push-chart.yml
@@ -1,0 +1,23 @@
+name: Auto trigger mch-repo
+
+on:
+  push:
+    branches:
+    - release-*
+    paths:
+    - 'stable/cluster-lifecycle/**'
+
+  workflow_dispatch:
+
+jobs:
+  notify-repo:
+    runs-on: ubuntu-latest
+    steps:
+      # Sends a dispatch event to multicloudhub-repo to trigger an update
+      - name: Notify Repo
+        uses: peter-evans/repository-dispatch@v1.1.3
+        with:
+          token: ${{ secrets.HUB_REPO_TOKEN }}
+          repository: open-cluster-management/multicloudhub-repo
+          event-type: chart-change
+          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}", "repository": "${{ github.repository }}"}'

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build-harness
 build-harness-extensions
 .DS_Store
 *.tgz
+!.github


### PR DESCRIPTION
Part of move to get off Travis. Jobs that were previously run in Travis are now handled by Github Action workflows. This PR will run chart linting on PRs, fast-forward the main branch to release-X.Y, and send a dispatch to multicloudhub-repo to pick up changes to the current release branch.