### PR TITLE
Updates for onboarding

### DIFF
--- a/stable/cluster-lifecycle/templates/cluster-curator-controller-deployment.yaml
+++ b/stable/cluster-lifecycle/templates/cluster-curator-controller-deployment.yaml
@@ -24,11 +24,30 @@ spec:
     metadata:
       labels:
         name: {{ .Values.ClusterCuratorController.name }}
+        ocm-antiaffinity-selector: "cluster-curator-controller"
     spec:
       {{- if .Values.global.imagePullSecret }}
       imagePullSecrets:
         - name: {{ .Values.global.imagePullSecret }}
       {{- end }}
+      {{- with .Values.clusterCuratorAffinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      tolerations:
+      - key: dedicated
+        operator: Exists
+        effect: NoSchedule
+      - effect: NoSchedule 
+        key: node-role.kubernetes.io/infra 
+        operator: Exists
+
+      serviceAccountName: {{ .Values.ClusterCuratorController.shortName }}
+      hostNetwork: false
+      hostPID: false
+      hostIPC: false
+      securityContext:
+        runAsNonRoot: true
       containers:
       - command: ["/bin/sh","-c"]
         args: ["./cluster-curator-controller || ./manager -enable-leader-election"]
@@ -40,8 +59,18 @@ spec:
               fieldPath: metadata.name
         - name: IMAGE_URI
           value: "{{ .Values.global.imageOverrides.cluster_curator_controller }}"
-        imagePullPolicy: Always
+        imagePullPolicy: "{{ .Values.global.imagePullPolicy }}"
         name: {{ .Values.ClusterCuratorController.name }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
         resources:
 {{ toYaml .Values.ClusterCuratorController.resources | indent 10 }}
-      serviceAccountName: {{ .Values.ClusterCuratorController.shortName }}
+      {{- with .Values.hubconfig.nodeSelector }}
+      nodeSelector:
+      {{ toYaml . | indent 8 }}
+      {{- end }}

--- a/stable/cluster-lifecycle/values.yaml
+++ b/stable/cluster-lifecycle/values.yaml
@@ -39,6 +39,38 @@ hubconfig:
   nodeSelector: null
   replicaCount: 2
 
+clusterCuratorAffinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: beta.kubernetes.io/arch
+          operator: In
+          values:
+          - amd64
+          - ppc64le
+          - s390x
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+    - weight: 70
+      podAffinityTerm:
+        topologyKey: topology.kubernetes.io/zone
+        labelSelector:
+          matchExpressions:
+          - key: ocm-antiaffinity-selector
+            operator: In
+            values:
+            - cluster-curator-controller
+    - weight: 35
+      podAffinityTerm:
+        topologyKey: kubernetes.io/hostname
+        labelSelector:
+          matchExpressions:
+          - key: ocm-antiaffinity-selector
+            operator: In
+            values:
+            - cluster-curator-controller
+
 affinity:
   nodeAffinity:
     requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
Signed off by @jnpacker 

* ImagePullPolicy must be defined in the values.yaml so it can be overridden by the MCH controller. Pull policy should not be hardcoded into deployment
* antiaffinity and tolerations must be added
* Nodeselector must be defined in the values yaml, so it can be overridden by the MCH controller
* Security Policies should be added  resembling the following to the deployment and container to ensure container runs with minimum necessary privileges. 

Issue reference: https://github.com/open-cluster-management/backlog/issues/10939