### PR TITLE
Add provider-credential-controller

### DIFF
--- a/stable/cluster-lifecycle/templates/provider-credential-clusterrole.yaml
+++ b/stable/cluster-lifecycle/templates/provider-credential-clusterrole.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.org }}.{{ .Release.Name }}.{{ .Values.ProviderCredentialController.shortName }}
+  labels:
+    app: {{ .Values.ProviderCredentialController.name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    component: {{ .Values.ProviderCredentialController.name }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ .Values.ProviderCredentialController.name }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+rules:
+
+# New Rules added to ClusterInstaller
+# Leader Lock requires configmaps(create&get) and pods(get)
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get","list","update","watch","patch"]
+
+# Leader election
+- apiGroups:
+  - ""
+  - coordination.k8s.io
+  resources:
+  - configmaps
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch

--- a/stable/cluster-lifecycle/templates/provider-credential-clusterrolebinding.yaml
+++ b/stable/cluster-lifecycle/templates/provider-credential-clusterrolebinding.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.org }}.{{ .Release.Name }}.{{ .Values.ProviderCredentialController.shortName }}
+  labels:
+    app: {{ .Values.ProviderCredentialController.name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    component: {{ .Values.ProviderCredentialController.name }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ .Values.ProviderCredentialController.name }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.ProviderCredentialController.shortName }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ .Values.org }}.{{ .Release.Name }}.{{ .Values.ProviderCredentialController.shortName }}
+  apiGroup: rbac.authorization.k8s.io

--- a/stable/cluster-lifecycle/templates/provider-credential-controller-deployment.yaml
+++ b/stable/cluster-lifecycle/templates/provider-credential-controller-deployment.yaml
@@ -1,0 +1,74 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.ProviderCredentialController.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Values.ProviderCredentialController.name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    component: {{ .Values.ProviderCredentialController.name }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ .Values.ProviderCredentialController.name }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: {{ .Values.ProviderCredentialController.name }}
+  template:
+    metadata:
+      labels:
+        name: {{ .Values.ProviderCredentialController.name }}
+    spec:
+      {{- if .Values.global.imagePullSecret }}
+      imagePullSecrets:
+        - name: {{ .Values.global.imagePullSecret }}
+      {{- end }}
+      {{- with .Values.providerCredentialAffinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      tolerations:
+      - key: dedicated
+        operator: Exists
+        effect: NoSchedule
+      - effect: NoSchedule 
+        key: node-role.kubernetes.io/infra 
+        operator: Exists
+
+      serviceAccountName: {{ .Values.ProviderCredentialController.shortName }}
+      hostNetwork: false
+      hostPID: false
+      hostIPC: false
+      securityContext:
+        runAsNonRoot: true
+
+      containers:
+      - command:
+        - "./manager"
+        - "-enable-leader-election"
+        image: "{{ .Values.global.imageOverrides.provider_credential_controller }}"
+        imagePullPolicy: "{{ .Values.global.imagePullPolicy }}"
+        name: {{ .Values.ProviderCredentialController.name }}
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+        resources:
+{{ toYaml .Values.ProviderCredentialController.resources | indent 10 }}
+      {{- with .Values.hubconfig.nodeSelector }}
+      nodeSelector:
+      {{ toYaml . | indent 8 }}
+      {{- end }}
+

--- a/stable/cluster-lifecycle/templates/provider-credential-service_account.yaml
+++ b/stable/cluster-lifecycle/templates/provider-credential-service_account.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.ProviderCredentialController.shortName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Values.ProviderCredentialController.name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    component: {{ .Values.ProviderCredentialController.name }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ .Values.ProviderCredentialController.name }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/stable/cluster-lifecycle/values.yaml
+++ b/stable/cluster-lifecycle/values.yaml
@@ -35,9 +35,52 @@ ClusterCuratorController:
       cpu: "3m"        # Runs < 2m most of the time
       memory: "25Mi"   # Runs between 25-28Mi
 
+ProviderCredentialController:
+  name: provider-credential-controller
+  shortName: provider-credential
+  resources:
+    limits:
+      cpu: "20m"
+      memory: "500Mi"
+    requests:
+      cpu: "3m"
+      memory: "65Mi"
+
 hubconfig:
   nodeSelector: null
   replicaCount: 2
+
+providerCredentialAffinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: beta.kubernetes.io/arch
+          operator: In
+          values:
+          - amd64
+          - ppc64le
+          - s390x
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+    - weight: 70
+      podAffinityTerm:
+        topologyKey: topology.kubernetes.io/zone
+        labelSelector:
+          matchExpressions:
+          - key: ocm-antiaffinity-selector
+            operator: In
+            values:
+            - provider-credential-controller
+    - weight: 35
+      podAffinityTerm:
+        topologyKey: kubernetes.io/hostname
+        labelSelector:
+          matchExpressions:
+          - key: ocm-antiaffinity-selector
+            operator: In
+            values:
+            - provider-credential-controller
 
 clusterCuratorAffinity:
   nodeAffinity:
@@ -181,6 +224,7 @@ global:
     registration_operator: "quay.io/open-cluster-management/registration-operator:0.0.1"
     registration: "quay.io/open-cluster-management/registration:0.0.1"
     cluster_curator_controller: "registry.ci.openshift.org/open-cluster-management/2.3:cluster-curator-controller"
+    provider_credential_controller: "registry.ci.openshift.org/open-cluster-management/2.3:provider-credential-controller"
     work: "quay.io/open-cluster-management/work:0.0.1"
     klusterlet_addon_controller: "quay.io/open-cluster-management/klusterlet-addon-controller:2.3.0"
     clusterlifecycle_state_metrics: "quay.io/open-cluster-management/clusterlifecycle-state-metrics:2.2.0"


### PR DESCRIPTION
Signed-off-by: Joshua Packer <jpacker@redhat.com>

* Add Provider Credential Controller to the product
- [x] 1. Code compiles
- [x] 2. Downstream available
- [x] 3. Helm chart Cluster-Lifecycle tested on `2.3.0-SNAPSHOT-2021-04-15-23-14-10`

/cc @leena-jawale 

Can you decide if you want to add put this through or wait until you make the ApiReader change.