### PR TITLE
add ppc64le and s390x architectures to klusterletAddonControllerAffinity

### DIFF
--- a/stable/cluster-lifecycle/values.yaml
+++ b/stable/cluster-lifecycle/values.yaml
@@ -178,6 +178,8 @@ klusterletAddonControllerAffinity:
           operator: In
           values:
           - amd64
+          - ppc64le
+          - s390x
   podAntiAffinity:
     preferredDuringSchedulingIgnoredDuringExecution:
     - weight: 70


### PR DESCRIPTION
Required for ppc64le hub support in ACM 2.3.
See https://github.com/open-cluster-management/backlog/issues/10617 for details.