### PR TITLE
increate resources to support 1000 clusters

### DIFF
--- a/stable/cluster-lifecycle/values.yaml
+++ b/stable/cluster-lifecycle/values.yaml
@@ -21,7 +21,7 @@ clusterController:
       memory: "96Mi"
       cpu: "50m"
     limits:
-      memory: "256Mi"
+      memory: "2Gi"
       cpu: "500m"
 
 ClusterCuratorController:
@@ -153,7 +153,7 @@ klusterletAddonController:
       memory: "96Mi"
       cpu: "50m"
     limits:
-      memory: "256Mi"
+      memory: "2Gi"
       cpu: "500m"
   addons:
     appmgr:


### PR DESCRIPTION
Signed-off-by: Hanqiu Zhang <hanzhang@redhat.com>

issue: https://github.com/open-cluster-management/backlog/issues/11798

Increased memory based on https://github.com/open-cluster-management/backlog/issues/11798#issuecomment-826959997
1Gi should be enough, but double to make sure we don't die that easy