### PR TITLE
Add destroy rules to role

### DIFF
--- a/stable/cluster-lifecycle/templates/cluster-curator-clusterole.yaml
+++ b/stable/cluster-lifecycle/templates/cluster-curator-clusterole.yaml
@@ -29,7 +29,7 @@ rules:
 
 - apiGroups: ["hive.openshift.io"]
   resources: ["clusterdeployments"]
-  verbs: ["patch"]
+  verbs: ["patch","delete"]
 
 - apiGroups: ["internal.open-cluster-management.io",""]
   resources: ["managedclusterinfos","pods"]
@@ -43,10 +43,15 @@ rules:
   resources: ["managedclusteractions"]
   verbs: ["get", "create", "update", "delete"]
 
-# Remove after ClusterCurator controller committed
-- apiGroups: ["cluster.open-cluster-management.io"] 
-  resources: ["managedclusters"]
-  verbs: ["watch","list"]
+# Only used by the controller
+
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["delete"]
+
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["list"]
 
 # ClusterCurator apiGroup
 - apiGroups:


### PR DESCRIPTION
Signed-off-by: Joshua Packer <jpacker@redhat.com>

* Remove the ManagedCluster list rule, as it is not used by the controller
* Tested chart upgrade:
```
helm upgrade cluster-lifecycle-b403b .
WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: /home/jpacker/.kube/config
WARNING: Kubernetes configuration file is world-readable. This is insecure. Location: /home/jpacker/.kube/config
I0604 16:19:02.069542   30796 request.go:645] Throttling request took 1.0353563s, request: GET:https://api.aws-4-7-cmx57.dev02.red-chesterfield.com:6443/apis/admission.work.open-cluster-management.io/v1?timeout=32s
Release "cluster-lifecycle-b403b" has been upgraded. Happy Helming!
NAME: cluster-lifecycle-b403b
LAST DEPLOYED: Fri Jun  4 16:19:06 2021
NAMESPACE: open-cluster-management
STATUS: deployed
REVISION: 2
TEST SUITE: None
NOTES:
You have successfully installed cluster-lifecycle-chart 2.3.0
```