### PR TITLE
Add get secrets to read install-config

### DIFF
--- a/stable/cluster-lifecycle/templates/cluster-curator-clusterole.yaml
+++ b/stable/cluster-lifecycle/templates/cluster-curator-clusterole.yaml
@@ -32,7 +32,7 @@ rules:
   verbs: ["patch","delete"]
 
 - apiGroups: ["internal.open-cluster-management.io",""]
-  resources: ["managedclusterinfos","pods"]
+  resources: ["managedclusterinfos","pods","secrets"]
   verbs: ["get"]
 
 - apiGroups: ["view.open-cluster-management.io"]


### PR DESCRIPTION
Signed-off-by: Joshua Packer <jpacker@redhat.com>

* Add permissions so that a role can be created for the job that allows the job to read the secret found in the cluster folder.