### PR TITLE
Fix provider credential deployment yaml

### DIFF
--- a/stable/cluster-lifecycle/templates/provider-credential-controller-deployment.yaml
+++ b/stable/cluster-lifecycle/templates/provider-credential-controller-deployment.yaml
@@ -67,10 +67,6 @@ spec:
           readOnlyRootFilesystem: true
         resources:
 {{ toYaml .Values.OldProviderConnectionController.resources | indent 10 }}
-      {{- with .Values.hubconfig.nodeSelector }}
-      nodeSelector:
-      {{ toYaml . | indent 8 }}
-      {{- end }}
       - command:
         - "./manager"
         - "-enable-leader-election"
@@ -95,4 +91,4 @@ spec:
       nodeSelector:
       {{ toYaml . | indent 8 }}
       {{- end }}
-
+      


### PR DESCRIPTION
Issue: https://github.com/open-cluster-management/backlog/issues/13872

Running `helm install` with a node-selector override reports the error 
```
YAML parse error on cluster-lifecycle/templates/provider-credential-controller-deployment.yaml: error converting YAML to JSON: yaml: line 101: did not find expected key
```

This was either caused by a whitespace error or the duplicate nodeSelector defined.

Signed-off-by: Jakob Gray <20209054+JakobGray@users.noreply.github.com>