### PR TITLE
Add clusterclaims

### DIFF
--- a/stable/cluster-lifecycle/templates/clusterclaims-clusterrole.yaml
+++ b/stable/cluster-lifecycle/templates/clusterclaims-clusterrole.yaml
@@ -1,0 +1,85 @@
+# Copyright Contributors to the Open Cluster Management project
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.org }}.{{ .Release.Name }}.{{ .Values.ClusterClaimsController.shortName }}
+  labels:
+    app: {{ .Values.ClusterClaimsController.name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    component: {{ .Values.ClusterClaimsController.name }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ .Values.ClusterClaimsController.name }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+rules:
+- apiGroups: ["hive.openshift.io"]
+  resources: ["clusterclaims","clusterpools"]
+  verbs: ["get","list","watch","update"]
+
+- apiGroups:
+  - "cluster.open-cluster-management.io"
+  - "agent.open-cluster-management.io"
+  resources:
+  - managedclusters
+  - klusterletaddonconfigs
+  verbs:
+  - get
+  - list
+  - create
+  - delete
+  - watch
+
+- apiGroups:
+  - "register.open-cluster-management.io"
+  resources:
+  - managedclusters/accept
+  verbs:
+  - update
+
+- apiGroups:
+  - "cluster.open-cluster-management.io"
+  resources:
+  - managedclustersets/join
+  verbs:
+  - create
+
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  - namespaces
+  verbs:
+  - list
+  - get
+  - delete
+
+# Leader election
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create

--- a/stable/cluster-lifecycle/templates/clusterclaims-clusterrole.yaml
+++ b/stable/cluster-lifecycle/templates/clusterclaims-clusterrole.yaml
@@ -17,7 +17,7 @@ metadata:
 rules:
 - apiGroups: ["hive.openshift.io"]
   resources: ["clusterclaims","clusterpools"]
-  verbs: ["get","list","watch","update"]
+  verbs: ["get","list","watch","update","patch"]
 
 - apiGroups:
   - "cluster.open-cluster-management.io"
@@ -54,6 +54,7 @@ rules:
   verbs:
   - list
   - get
+  - watch
   - delete
 
 # Leader election

--- a/stable/cluster-lifecycle/templates/clusterclaims-controller-deployment.yaml
+++ b/stable/cluster-lifecycle/templates/clusterclaims-controller-deployment.yaml
@@ -1,0 +1,95 @@
+# Copyright Contributors to the Open Cluster Management project.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:  
+  name: {{ .Values.ClusterClaimsController.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Values.ClusterClaimsController.name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    component: {{ .Values.ClusterClaimsController.name }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ .Values.ClusterClaimsController.name }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+spec:
+  replicas: {{ .Values.hubconfig.replicaCount }}
+  selector:
+    matchLabels:
+      name: {{ .Values.ClusterClaimsController.name }}
+  template:
+    metadata:
+      labels:
+        name: {{ .Values.ClusterClaimsController.name }}
+        ocm-antiaffinity-selector: "clusterclaims-controller"
+    spec:
+      {{- if .Values.global.imagePullSecret }}
+      imagePullSecrets:
+        - name: {{ .Values.global.imagePullSecret }}
+      {{- end }}
+      {{- with .Values.clusterClaimsAffinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      tolerations:
+      - key: dedicated
+        operator: Exists
+        effect: NoSchedule
+      - effect: NoSchedule 
+        key: node-role.kubernetes.io/infra 
+        operator: Exists
+
+      serviceAccountName: {{ .Values.ClusterClaimsController.shortName }}
+      hostNetwork: false
+      hostPID: false
+      hostIPC: false
+      securityContext:
+        runAsNonRoot: true
+      containers:
+      - command:
+          - "./manager-clusterclaims"
+          - "-enable-leader-election"
+        image: "{{ .Values.global.imageOverrides.clusterclaims_controller }}"
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        imagePullPolicy: "{{ .Values.global.imagePullPolicy }}"
+        name: {{ .Values.ClusterClaimsController.name }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+        resources:
+{{ toYaml .Values.ClusterClaimsController.resources | indent 10 }}
+      - command:
+        - "./manager-clusterpools-delete"
+        - "-enable-leader-election"
+        image: "{{ .Values.global.imageOverrides.clusterclaims_controller }}"
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        imagePullPolicy: "{{ .Values.global.imagePullPolicy }}"
+        name: {{ .Values.ClusterpoolsDeleteController.name }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+        resources:
+{{ toYaml .Values.ClusterClaimsController.resources | indent 10 }}
+      {{- with .Values.hubconfig.nodeSelector }}
+      nodeSelector:
+      {{ toYaml . | indent 8 }}
+      {{- end }}

--- a/stable/cluster-lifecycle/templates/clusterclaims-rolebinding.yaml
+++ b/stable/cluster-lifecycle/templates/clusterclaims-rolebinding.yaml
@@ -1,0 +1,25 @@
+# Copyright Contributors to the Open Cluster Management project
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.org }}.{{ .Release.Name }}.{{ .Values.ClusterClaimsController.shortName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Values.ClusterClaimsController.name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    component: {{ .Values.ClusterClaimsController.name }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ .Values.ClusterClaimsController.name }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.ClusterClaimsController.shortName }}
+  namespace: {{ .Release.Namespace }}           ## CHANGE: ACM namespace
+roleRef:
+  kind: ClusterRole
+  name: {{ .Values.org }}.{{ .Release.Name }}.{{ .Values.ClusterClaimsController.shortName }}
+  apiGroup: rbac.authorization.k8s.io

--- a/stable/cluster-lifecycle/templates/clusterclaims-service_account.yaml
+++ b/stable/cluster-lifecycle/templates/clusterclaims-service_account.yaml
@@ -1,0 +1,17 @@
+# Copyright Contributors to the Open Cluster Management project
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.ClusterClaimsController.shortName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Values.ClusterClaimsController.name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    component: {{ .Values.ClusterClaimsController.name }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ .Values.ClusterClaimsController.name }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/stable/cluster-lifecycle/values.yaml
+++ b/stable/cluster-lifecycle/values.yaml
@@ -36,6 +36,20 @@ ClusterCuratorController:
       cpu: "3m"        # Runs < 2m most of the time
       memory: "25Mi"   # Runs between 25-28Mi
 
+ClusterClaimsController:
+  name: clusterclaims-controller
+  shortName: clusterclaims
+  resources:
+    limits:
+      cpu: "20m"
+      memory: "500Mi"
+    requests:
+      cpu: "3m"
+      memory: "65Mi"
+
+ClusterpoolsDeleteController:
+  name: clusterpools-delete-controller
+
 ProviderCredentialController:
   name: provider-credential-controller
   shortName: provider-credential
@@ -138,6 +152,38 @@ clusterCuratorAffinity:
             operator: In
             values:
             - cluster-curator-controller
+
+clusterClaimsAffinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: beta.kubernetes.io/arch
+          operator: In
+          values:
+          - amd64
+          - ppc64le
+          - s390x
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+    - weight: 70
+      podAffinityTerm:
+        topologyKey: topology.kubernetes.io/zone
+        labelSelector:
+          matchExpressions:
+          - key: ocm-antiaffinity-selector
+            operator: In
+            values:
+            - clusterclaims-controller
+    - weight: 35
+      podAffinityTerm:
+        topologyKey: kubernetes.io/hostname
+        labelSelector:
+          matchExpressions:
+          - key: ocm-antiaffinity-selector
+            operator: In
+            values:
+            - clusterclaims-controller
 
 affinity:
   nodeAffinity:

--- a/stable/cluster-lifecycle/values.yaml
+++ b/stable/cluster-lifecycle/values.yaml
@@ -301,3 +301,5 @@ global:
     work: "quay.io/open-cluster-management/work:0.0.1"
     klusterlet_addon_controller: "quay.io/open-cluster-management/klusterlet-addon-controller:2.3.0"
     clusterlifecycle_state_metrics: "quay.io/open-cluster-management/clusterlifecycle-state-metrics:2.3.0"
+    clusterclaims_controller: "quay.io/open-cluster-management/clusterclaims-controller:2.4.0"
+


### PR DESCRIPTION
Signed off by jpacker@redhat.com

* Add the new clusterClaims and clusterPools-delete controllers.
* ClusterClaims-controller
  * Handles creating a ManagedCluster and KlusterletAddonConfig. Good for GitOps and removes complexity from the console
  * Copies labels from ClusterClaim to ManagedCluster
  * deletes the appropriate resources
 * ClusterPools-delete-controller
   * Removes the secrets associated with a clusterPool. These are currently not being cleaned up.