### PR TITLE
Add new rules to allow collection of region information

### DIFF
--- a/stable/cluster-lifecycle/templates/clusterclaims-clusterrole.yaml
+++ b/stable/cluster-lifecycle/templates/clusterclaims-clusterrole.yaml
@@ -19,6 +19,10 @@ rules:
   resources: ["clusterclaims","clusterpools"]
   verbs: ["get","list","watch","update","patch"]
 
+- apiGroups: ["hive.openshift.io"]
+  resources: ["clusterdeployments"]
+  verbs: ["get","list","watch"]
+
 - apiGroups:
   - "cluster.open-cluster-management.io"
   - "agent.open-cluster-management.io"


### PR DESCRIPTION
Signed-off-by: Joshua Packer <jpacker@redhat.com>

* These permissions are needed to allow the ClusterClaims controller to read the region from the ClusterDeployment.Spec.Platform.<Provider>.Region  parameter.