### PR TITLE
Allow appmgr addon to edit new subscriptionreport resources in hub cluster namespace

### DIFF
--- a/stable/cluster-lifecycle/templates/klusterlet-addon-appmgr-role.yaml
+++ b/stable/cluster-lifecycle/templates/klusterlet-addon-appmgr-role.yaml
@@ -67,7 +67,6 @@ rules:
 - apiGroups:
   - apps.open-cluster-management.io
   resources:
-  - subscriptionstatuses
   - subscriptionreports
   verbs:
   - get

--- a/stable/cluster-lifecycle/templates/klusterlet-addon-appmgr-role.yaml
+++ b/stable/cluster-lifecycle/templates/klusterlet-addon-appmgr-role.yaml
@@ -64,3 +64,16 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - apps.open-cluster-management.io
+  resources:
+  - subscriptionstatuses
+  - subscriptionreports
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch
+  - update
+  - delete


### PR DESCRIPTION
Signed-off-by: Xiangjing Li <xiangli@redhat.com>

This is to allow appmgr addon to be able to edit new subscriptionReport resources in cluster namespace on the hub. The new subscriptionReport api is introduced in ACM 2.5